### PR TITLE
shrunk all logo images so they don't take up the half the sceen. Also…

### DIFF
--- a/tile_backend/resources/views/home.blade.php
+++ b/tile_backend/resources/views/home.blade.php
@@ -22,7 +22,7 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="d-flex justify-content-center m-2">
-                <img src="{{asset("./logo.png")}}" class =" w-50 "alt="">
+                <img src="{{asset("./logo.png")}}" class =" w-25"alt="">
             </div>
             <div class="card">
                 <div class="card-header">{{ __('My Tokens') }}</div>

--- a/tile_backend/resources/views/informational/about.blade.php
+++ b/tile_backend/resources/views/informational/about.blade.php
@@ -5,7 +5,7 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="d-flex justify-content-center m-2">
-                <img src="{{asset("./logo.png")}}" class =" w-50 "alt="">
+                <img src="{{asset("./logo.png")}}" class =" w-25 "alt="">
             </div>
             <div class="card">
                 <div class="card-header">{{ __('About') }}</div>

--- a/tile_backend/resources/views/informational/documentation.blade.php
+++ b/tile_backend/resources/views/informational/documentation.blade.php
@@ -5,7 +5,7 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="d-flex justify-content-center m-2">
-                <img src="{{asset("./logo.png")}}" class =" w-50 "alt="">
+                <img src="{{asset("./logo.png")}}" class =" w-25 "alt="">
             </div>
             <div class="card">
                 <div class="card-header">{{ __('Documentation') }}</div>

--- a/tile_backend/resources/views/informational/tutorial.blade.php
+++ b/tile_backend/resources/views/informational/tutorial.blade.php
@@ -5,7 +5,7 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="d-flex justify-content-center m-2">
-                <img src="{{asset("./logo.png")}}" class =" w-50 "alt="">
+                <img src="{{asset("./logo.png")}}" class =" w-25 "alt="">
             </div>
             <div class="card">
                 <div class="card-header">{{ __('Tutorial') }}</div>

--- a/tile_backend/resources/views/tokens/create.blade.php
+++ b/tile_backend/resources/views/tokens/create.blade.php
@@ -8,7 +8,7 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="d-flex justify-content-center m-2">
-                <img src="{{asset("./logo.png")}}" class =" w-50 "alt="">
+                <img src="{{asset("./logo.png")}}" class =" w-25 "alt="">
             </div>            <div class="card">
                 <div class="card-header">{{ __('Create Token') }}</div>
                 <div class="card-body">

--- a/tile_backend/resources/views/viewer.blade.php
+++ b/tile_backend/resources/views/viewer.blade.php
@@ -1,9 +1,9 @@
 @extends('layouts.app')
 
 @section('content')
-      <a href="https://www.bathmap.net/" class="d-flex justify-content-center">
-        <img src="{{asset("./logo.png")}}" alt="Logo" style="width:20em;height:20em;float:right" >
-      </a>
+      <div class="d-flex justify-content-center">
+        <img src="{{asset("./logo.png")}}" alt="Logo" style="width:15em;height:14em;float:right"  class="mt-2" >
+      </div>
       <div class="d-flex justify-content-center">
           <select name="gridID" id="grid_selector">
             <option value="" selected >All Locations</option>

--- a/tile_backend/resources/views/welcome.blade.php
+++ b/tile_backend/resources/views/welcome.blade.php
@@ -29,7 +29,7 @@
 
             <div class="max-w-7xl mx-auto p-6 lg:p-8">
                 <div >
-                    <img src="{{asset("./logo.png")}}" style="height:500px;"class =" border  rounded max-width m-auto "alt="">
+                    <img src="{{asset("./logo.png")}}" style="height:300px;"class =" border  rounded max-width m-auto "alt="">
                 </div>
               
                 <div class="mt-16">


### PR DESCRIPTION
… removed the link from the viewer logo

This does three things:

- shrinks logos so they aren't taking up half the screen
- remove link from viewer logo
- Making logos that are not on the main page all the same size